### PR TITLE
fix: convert AF1 fragment containers; guard optional property removal

### DIFF
--- a/core/src/main/java/com/adobe/aem/core/rules/AdaptiveFormGuideContainerRewriterRule.java
+++ b/core/src/main/java/com/adobe/aem/core/rules/AdaptiveFormGuideContainerRewriterRule.java
@@ -70,8 +70,8 @@ public class AdaptiveFormGuideContainerRewriterRule extends AbstractAdaptiveForm
             container.setProperty(FD_VERSION, CORE_COMPONENT_VERSION);
             container.setProperty(FIELD_TYPE, FIELD_TYPE_FORM);
             container.setProperty(THEME_REF, CANVAS_THEME_PATH);
-            container.getProperty(GUIDE_NODE_CLASS).remove();
-            container.getProperty(GUIDE_CSS).remove();
+            if (container.hasProperty(GUIDE_NODE_CLASS)) container.getProperty(GUIDE_NODE_CLASS).remove();
+            if (container.hasProperty(GUIDE_CSS)) container.getProperty(GUIDE_CSS).remove();
             if (GUIDE_CONTAINER_RESOURCE_TYPE.equals(guideResourceType) || GUIDE_CONTAINER_WRAPPER_RESOURCE_TYPE.equals(guideResourceType)) {
                 container.setProperty(SLING_RESOURCE_TYPE_PROPERTY, CORE_FORM_CONTAINER_RESOURCE_TYPE);
             } else if(GUIDE_FRAGMENT_CONTAINER_RESOURCE_TYPE.equals(guideResourceType)){

--- a/core/src/main/java/com/adobe/aem/core/rules/AdaptiveFormGuidePanelRewriterRule.java
+++ b/core/src/main/java/com/adobe/aem/core/rules/AdaptiveFormGuidePanelRewriterRule.java
@@ -137,7 +137,7 @@ public class AdaptiveFormGuidePanelRewriterRule extends AbstractAdaptiveFormComp
             panelContainer.setProperty(FIELD_TYPE, PANEL);
             panelContainer.setProperty(FRAGMENT_PATH, panelContainer.getProperty(FRAGMENT_REF).getString());
             panelContainer.getProperty(FRAGMENT_REF).remove();
-            panelContainer.getProperty(GUIDE_NODE_CLASS).remove();
+            if (panelContainer.hasProperty(GUIDE_NODE_CLASS)) panelContainer.getProperty(GUIDE_NODE_CLASS).remove();
         }
     }
 }

--- a/core/src/main/java/com/adobe/aem/core/rules/AdaptiveFormGuideTableRewriterRule.java
+++ b/core/src/main/java/com/adobe/aem/core/rules/AdaptiveFormGuideTableRewriterRule.java
@@ -100,10 +100,10 @@ public class AdaptiveFormGuideTableRewriterRule extends AbstractAdaptiveFormComp
                         if (bindRef != null) {
                             updateBindRefForNonRepeatableParent(tableRowContainer.getNode(rowNode.getName()), bindRef, null, null);
                         }
-                        rowNode.getProperty(SLING_RESOURCE_TYPE_PROPERTY).remove();
+                        if (rowNode.hasProperty(SLING_RESOURCE_TYPE_PROPERTY)) rowNode.getProperty(SLING_RESOURCE_TYPE_PROPERTY).remove();
                     }
                 }
-                tableRowComponent.getProperty(SLING_RESOURCE_TYPE_PROPERTY).remove();
+                if (tableRowComponent.hasProperty(SLING_RESOURCE_TYPE_PROPERTY)) tableRowComponent.getProperty(SLING_RESOURCE_TYPE_PROPERTY).remove();
                 copyTableNodeChildren(tableRowComponent, tableRowContainer);
             }
         }
@@ -115,7 +115,7 @@ public class AdaptiveFormGuideTableRewriterRule extends AbstractAdaptiveFormComp
 
     private Node getTableContainer(Node tableComponent, Node tableContainer) throws RepositoryException {
         tableContainer = createNodeAndCopyProperties(tableComponent, tableContainer, tableComponent.getName());
-        tableContainer.getProperty(GUIDE_NODE_CLASS).remove();
+        if (tableContainer.hasProperty(GUIDE_NODE_CLASS)) tableContainer.getProperty(GUIDE_NODE_CLASS).remove();
         tableContainer.setProperty(FIELD_TYPE, PANEL);
         tableContainer.setProperty(HIDE_TITLE, true);
         tableContainer.setProperty(LAYOUT_PROPERTY, RESPONSIVE_GRID);
@@ -161,7 +161,7 @@ public class AdaptiveFormGuideTableRewriterRule extends AbstractAdaptiveFormComp
             Node node = nodeIterator.nextNode();
             if(!PANEL_NODES_TO_IGNORE.contains(node.getName())) {
                 JcrUtil.copy(node, panelNode, node.getName());
-                node.getProperty(SLING_RESOURCE_TYPE_PROPERTY).remove();
+                if (node.hasProperty(SLING_RESOURCE_TYPE_PROPERTY)) node.getProperty(SLING_RESOURCE_TYPE_PROPERTY).remove();
             }
         }
     }

--- a/core/src/main/java/com/adobe/aem/core/utils/AdaptiveFormConstants.java
+++ b/core/src/main/java/com/adobe/aem/core/utils/AdaptiveFormConstants.java
@@ -149,6 +149,6 @@ public class AdaptiveFormConstants {
     public static final String CORE_SUBMIT_ACTION_RESOURCE_TYPE = COMPONENT_PATH_PREFIX + "actions/submit";
     public static final String CORE_RESET_ACTION_RESOURCE_TYPE = COMPONENT_PATH_PREFIX + "actions/reset";
     public final static List<String> GRID_LAYOUTS = Arrays.asList("fd/af/layouts/gridFluidLayout", "fd/af/layouts/gridFluidLayout2", "fd/af/layouts/defaultGuideLayout");
-    public final static List<String> PANEL_NODES_TO_IGNORE = Arrays.asList("layout", "items");
+    public final static List<String> PANEL_NODES_TO_IGNORE = Arrays.asList("layout", "items", "toolbar");
     public final static List<String> CONTAINER_NODES_TO_IGNORE = Arrays.asList("parsys1", "parsys2", "layout", "rootPanel");
 }

--- a/core/src/main/java/com/adobe/aem/core/utils/AdaptiveFormUtils.java
+++ b/core/src/main/java/com/adobe/aem/core/utils/AdaptiveFormUtils.java
@@ -50,7 +50,7 @@ public class AdaptiveFormUtils {
         if (checkIfNodeCanBeDeleted(node)) {
             Node parent = node.getParent();
             node.remove();
-            if (parent.getName().equals(GUIDE_CONTAINER) || parent.getName().equals(GUIDE_CONTAINER_WRAPPER)) {
+            if (parent.getName().equals(GUIDE_CONTAINER) || parent.getName().equals(GUIDE_CONTAINER_WRAPPER) || parent.getName().equals(GUIDE_FRAGMENT_CONTAINER)) {
                 String initialName = parent.getName();
                 Node guideContainerParent = parent.getParent();
                 parent.remove();
@@ -74,9 +74,11 @@ public class AdaptiveFormUtils {
                 newPanel.setProperty(FIELD_TYPE, PANEL);
                 newPanel.setProperty(HIDE_TITLE, true);
                 newPanel.setProperty(SLING_RESOURCE_TYPE_PROPERTY, LAYOUT_RESOURCE_TYPE_MAPPINGS.get(layoutType));
-                newPanel.getProperty(GUIDE_NODE_CLASS).remove();
+                if (newPanel.hasProperty(GUIDE_NODE_CLASS)) newPanel.getProperty(GUIDE_NODE_CLASS).remove();
             } else if (!isRootPanel) {
                 newPanel = createNodeAndCopyProperties(panelContainer, newContainer, panelContainer.getName());
+                newPanel.setProperty(SLING_RESOURCE_TYPE_PROPERTY, CORE_PANEL_RESOURCE_TYPE);
+                newPanel.setProperty(FIELD_TYPE, PANEL);
             }
             if (isRepeatablePanel(panelContainer)) {
                 newPanel.setProperty(REPEATABLE, true);
@@ -89,8 +91,8 @@ public class AdaptiveFormUtils {
     public static void populateResourceTypeForLayout(String coreWizardResourceType, String coreTabsOnTopResourceType,
                                                      String coreVerticalTabsResourceType, String coreAccordionResourceType) {
         LAYOUT_RESOURCE_TYPE_MAPPINGS.put(WIZARD_RESOURCE_TYPE, coreWizardResourceType);
-        LAYOUT_RESOURCE_TYPE_MAPPINGS.put(VERTICAL_TABS_RESOURCE_TYPE, coreTabsOnTopResourceType);
-        LAYOUT_RESOURCE_TYPE_MAPPINGS.put(TABS_ON_TOP_RESOURCE_TYPE, coreVerticalTabsResourceType);
+        LAYOUT_RESOURCE_TYPE_MAPPINGS.put(VERTICAL_TABS_RESOURCE_TYPE, coreVerticalTabsResourceType);
+        LAYOUT_RESOURCE_TYPE_MAPPINGS.put(TABS_ON_TOP_RESOURCE_TYPE, coreTabsOnTopResourceType);
         LAYOUT_RESOURCE_TYPE_MAPPINGS.put(ACCORDION_RESOURCE_TYPE, coreAccordionResourceType);
     }
 


### PR DESCRIPTION
Two root causes prevented all fragment containers from converting:

1. ContainerRewriterRule: getProperty(GUIDE_NODE_CLASS/GUIDE_CSS).remove() without hasProperty() check. Fragment containers lack these optional AF1 UI properties. PathNotFoundException was swallowed by the catch block; v2Path was never set, stalling RootPanelRule and CommonGuideComponentsRewriterRule for the fragment.

2. AdaptiveFormUtils.deleteFormNodes: rename step only handled guideContainer and guideContainerWrapper. Fragment containers (guideFragmentContainer) fell through to recursive branch which hit the new AF2 container node (has sling:resourceType), causing checkIfNodeCanBeDeleted to return false — temp container never renamed.

Additional fixes in AdaptiveFormUtils:
- handleLayoutNode: add hasProperty guard for GUIDE_NODE_CLASS
- handleLayoutNode else branch: set CORE_PANEL_RESOURCE_TYPE + FIELD_TYPE on plain panels (was carrying over AF1 sling:resourceType)
- populateResourceTypeForLayout: fix VERTICAL_TABS <-> TABS_ON_TOP argument swap

Defensive hasProperty guards in PanelRule.handleFragmentPanel and TableRule (getTableContainer, processTableNode rows/cells, copyTableNodeChildren) — same unsafe pattern that caused the ContainerRule failure.

AdaptiveFormConstants: add 'toolbar' to PANEL_NODES_TO_IGNORE to prevent toolbar nodes from being duplicated during panel copy.