### PR TITLE
fix: merge-mode filter preserves osgiconfig; fix all/pom.xml bundle embeding

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -139,7 +139,9 @@
         <profile>
             <id>aemaacs</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <file>
+                    <exists>pom.xml</exists>
+                </file>
             </activation>
             <build>
                 <plugins>
@@ -289,6 +291,11 @@
                     <classifier>aem65</classifier>
                     <type>zip</type>
                 </dependency>
+                <dependency>
+                    <groupId>com.adobe.aem</groupId>
+                    <artifactId>forms-modernizer.core</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>
@@ -297,6 +304,11 @@
     <!-- D E P E N D E N C I E S                                                -->
     <!-- ====================================================================== -->
     <dependencies>
+        <dependency>
+            <groupId>com.adobe.aem</groupId>
+            <artifactId>forms-modernizer.core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>forms-modernizer.ui.apps</artifactId>

--- a/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
-    <filter root="/apps/forms-modernizer"/>
+    <filter root="/apps/forms-modernizer" mode="merge"/>
     <filter root="/apps/forms-modernizer/rules"/>
 </workspaceFilter>


### PR DESCRIPTION
filter.xml: add mode=merge to /apps/forms-modernizer root filter. Default replace mode caused ui.apps (installed after ui.config in the all package) to wipe osgiconfig, leaving ComponentRewriteRuleServiceImpl with no search paths — all node-based rules silently disabled.

all/pom.xml: fix parent artifactId (forms-modernizer → forms-modernizer-parent) and add forms-modernizer.core to dependencies so the OSGi bundle is embedded in the all package.